### PR TITLE
Archive lab.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+repository:
+  name: byzantine-config
+  description: GUI Utility that simplifies creating configuration blocks and generating user keys
+  homepage: https://byzantinetools.com/
+  archived: true
+  private: false


### PR DESCRIPTION
Archived labs are read-only, and they can be moved back out of the archives, if there is interest in reviving them.
    
Signed-off-by: Tracy Kuhrt <tracy.a.kuhrt@accenture.com>